### PR TITLE
Test a bunch of types

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,81 @@
 using JuliaBLAS, Test, LinearAlgebra
 
-@testset "Matrix Multiplication Tests" begin
-    siz = (3, 5, 9, 13, 32, 200)
-    for m in siz, n in siz, k in siz
-        C = rand(m, n)
-        A = rand(m, k)
-        B = rand(k, n)
-        ABC = A*B + C
-        mymul!(C, A, B, Block(A,B,C,false))
-        @test C ≈ ABC
-        ABC = A*B + C
-        mymul!(C, A, B, Block(A,B,C,true))
-        @test C ≈ ABC
+
+function matmul_test(name, datagen, generic_only = false)
+    @testset "$name" begin
+        siz = (3, 5, 9, 13, 32, 200)
+        for m in siz, n in siz, k in siz
+            C = datagen(m, n)
+            A = datagen(m, k)
+            B = datagen(k, n)
+            ABC = A*B + C
+			@test true # ensure base functionality doesn't error out before here
+            
+            if !generic_only
+                mymul!(C, A, B, Block(A,B,C,false))
+                @test C ≈ ABC
+            end
+
+            ABC = A*B + C
+            mymul!(C, A, B, Block(A,B,C,true))
+            @test C ≈ ABC
+        end
     end
+end
+
+
+
+# Weird type, with weird math
+struct Stringish
+	str::String
+end
+
+Stringish(x) = Stringish(string(x))
+
+Base.zero(::Stringish) = Stringish("")
+Base.one(::Stringish) = Stringish("")
+Base.:+(s1::Stringish, s2::Stringish) = Stringish(s1.str * s2.str)
+Base.:*(s1::Stringish, s2::Stringish) = Stringish("[$(s1.str),$(s2.str)]")
+
+Base.rand(::Type{Stringish}, (m, n)::Tuple{Int64, Int64}) = [Stringish(rand(0:9)) for ii in 1:m, jj in 1:n]
+Base.:≈(x::Stringish, y::Stringish) = x.str == y.str
+#################################################################
+
+
+datagen(T) = (m,n) -> rand(T, (m,n))
+
+@testset "Matrix Multiplication Tests" begin
+    for T in [
+			  Int128,
+              Int16,
+              Int32,
+              Int64,
+              Int8,
+              UInt128,
+              UInt16,
+              UInt32,
+              UInt64,
+              UInt8,
+              Float16,
+              Float32,
+              Float64,
+              Bool]
+
+        matmul_test(string(T), datagen(T))
+		T = Complex{T}
+        matmul_test(string(T), datagen(T))
+    end
+    
+
+    for T in [BigFloat,]
+		matmul_test(string(T), datagen(T), true)
+		T = Complex{T}
+        matmul_test(string(T), datagen(T), true)
+    end
+
+	matmul_test(string(Stringish), datagen(Stringish), true)
+
+    matmul_test(string(BigInt), (m,n) -> rand(-big"2"^256 : big"2"^256, (m,n)), true)
+
+
 end


### PR DESCRIPTION
I am a bit excite.

I wanted to check the coverage of various types.
The answer is not great.
But I think it is nice to have a check-list showing status.

```
Test Summary:               | Pass  Error  Total
Matrix Multiplication Tests | 2622     27   2649
  Int128                    |    1      1      2
  Complex{Int128}           |    1      1      2
  Int16                     |    1      1      2
  Complex{Int16}            |    1      1      2
  Int32                     |    1      1      2
  Complex{Int32}            |    1      1      2
  Int64                     |  648           648
  Complex{Int64}            |    1      1      2
  Int8                      |    1      1      2
  Complex{Int8}             |    1      1      2
  UInt128                   |    1      1      2
  Complex{UInt128}          |    1      1      2
  UInt16                    |    1      1      2
  Complex{UInt16}           |    1      1      2
  UInt32                    |    1      1      2
  Complex{UInt32}           |    1      1      2
  UInt64                    |  648           648
  Complex{UInt64}           |    1      1      2
  UInt8                     |    1      1      2
  Complex{UInt8}            |    1      1      2
  Float16                   |    1      1      2
  Complex{Float16}          |    1      1      2
  Float32                   |  648           648
  Complex{Float32}          |    1      1      2
  Float64                   |  648           648
  Complex{Float64}          |    1      1      2
  Bool                      |    4      1      5
  Complex{Bool}             |    1      1      2
  BigFloat                  |    1      1      2
  Stringish                 |    1      1      2
  BigInt                    |    1      1      2
```

I may have screws up which types generic should be turned on.
I feel like generic can and should be made automatically set,
for input types that are not SIMD-able.